### PR TITLE
Very slight Node reformulation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ int main( ){
       std::vector< double >{1.0, 2.0, 3.0, 4.0} };
   auto& vec = vNode.get< std::vector< double > >();
   cout << endl;
-  cout << "vNode has values: " 
-       << vec[0] << ", " 
-       << vec[1] << ", " 
-       << vec[2] << ", " 
-       << vec[3] << ", " 
+  cout << "vNode has values: "
+       << vec[0] << ", "
+       << vec[1] << ", "
+       << vec[2] << ", "
+       << vec[3] << ", "
        << endl;
 }
 ```

--- a/src/knoop.hpp
+++ b/src/knoop.hpp
@@ -3,10 +3,10 @@
 
 #include <map>
 #include <list>
+#include <variant>
 
 #include <range/v3/all.hpp>
 #include "value-ptr.hpp"
-#include <variant>
 
 namespace njoy {
 namespace knoop {

--- a/src/knoop/Node.hpp
+++ b/src/knoop/Node.hpp
@@ -1,10 +1,10 @@
 template< typename... Ts >
 using void_t = void;
 
-template< typename... Ls >
+template< typename L, typename... Ls >
 class Node {
 public:
-  using leaf_type = std::variant< Ls... >;
+  using leaf_type = std::variant< L, Ls... >;
   using list_type = std::list< Node >;
   using list_iterator = typename list_type::iterator;
   using ptr_type = valuable::value_ptr< Node >;

--- a/src/knoop/Node/src/erase.hpp
+++ b/src/knoop/Node/src/erase.hpp
@@ -1,10 +1,10 @@
-Node& erase( list_iterator it ){
+Node& erase( const list_iterator it ){
   auto& list = std::get< list_type >( core );
   list.erase( it );
   return *this;
 }
 
-Node& erase( list_iterator begin, list_iterator end ){
+Node& erase( const list_iterator begin, const list_iterator end ){
   auto& list = std::get< list_type >( core );
   list.erase( begin, end );
   return *this;

--- a/src/knoop/Node/src/get.hpp
+++ b/src/knoop/Node/src/get.hpp
@@ -9,3 +9,13 @@ T& get(){
   auto& leaf = std::get< leaf_type >( core );
   return std::get<T>(leaf);
 }
+
+const L& get() const {
+  const auto& leaf = std::get< leaf_type >( core );
+  return std::get<L>(leaf);
+}
+
+L& get(){
+  auto& leaf = std::get< leaf_type >( core );
+  return std::get<L>(leaf);
+}

--- a/src/knoop/Node/src/insert.hpp
+++ b/src/knoop/Node/src/insert.hpp
@@ -9,14 +9,14 @@ Node& insert( Str&& str, T&& t ){
 }
 
 template< typename T >
-Node& insert( list_iterator it, T&& t ){
+Node& insert( const list_iterator it, T&& t ){
   auto& list = std::get< list_type >( core );
   list.insert(it, std::forward<T>(t) );
   return *this;
 }
 
 template< typename T, typename... Args >
-Node& insert( list_iterator it, T&& t, Args&&... args ){
+Node& insert( const list_iterator it, T&& t, Args&&... args ){
   auto& list = std::get< list_type >( core );
   list.insert(it, std::forward<T>(t) );
   return this->insert(it, std::forward<Args>(args)... );

--- a/src/knoop/Node/test/CMakeLists.txt
+++ b/src/knoop/Node/test/CMakeLists.txt
@@ -17,5 +17,5 @@ $<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
 $<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
 
 ${CXX_appended_flags} ${knoop_appended_flags} )
-target_link_libraries( knoop.Node.test PUBLIC knoop ) 
+target_link_libraries( knoop.Node.test PUBLIC knoop )
 add_test( NAME knoop.Node COMMAND knoop.Node.test )

--- a/src/knoop/Node/test/assignment.test.cpp
+++ b/src/knoop/Node/test/assignment.test.cpp
@@ -4,9 +4,8 @@
 using namespace njoy::knoop;
 using Node_t = Node<int, std::string>;
 
-// this functions are a workaround for isuues in the interaction between
-// C macros (like Catch's REQUIRE statement) and C++ template
-// instatiations;
+// These functions are a workaround for issues in the interaction between
+// C macros (like Catch's REQUIRE) and C++ template instantiations:
 
 int& getInt(Node_t& node);
 const int& getInt(const Node_t& node);

--- a/src/knoop/Node/test/example.cpp
+++ b/src/knoop/Node/test/example.cpp
@@ -49,14 +49,14 @@ SCENARIO( "Simulating GNDS" ){
 
   GIVEN( "a node with some attributes and a 'child'" ){
 
-    auto gndsNode = 
+    auto gndsNode =
         GNDSNode( "person",
-          Attribute{ "name", "Anakin" }, 
+          Attribute{ "name", "Anakin" },
           Attribute{ "surname", "Skywalker"},
-          GNDSNode( "person", 
+          GNDSNode( "person",
                     Attribute{ "name", "Luke" },
                     Attribute{ "surname", "Skywalker" } ),
-          GNDSNode( "person", 
+          GNDSNode( "person",
                    Attribute{ "name", "Obi-Wan" },
                    Attribute{ "surname", "Kenobi" } ) );
 
@@ -71,7 +71,7 @@ SCENARIO( "Simulating GNDS" ){
       REQUIRE( 2 == gndsNode[ "children" ].list().size() );
     }
 
-    auto isSkywalker = []( const Node_t& node ){ 
+    auto isSkywalker = []( const Node_t& node ){
       auto surname = node[ "attributes" ][ "surname" ]. get< std::string>();
       return surname == "Skywalker";
     };
@@ -83,8 +83,8 @@ SCENARIO( "Simulating GNDS" ){
       REQUIRE( isSkywalker( children.front() ) );
 
       WHEN( "children are added" ){
-        gndsNode[ "children" ].push_back( 
-          GNDSNode( "person", 
+        gndsNode[ "children" ].push_back(
+          GNDSNode( "person",
                     Attribute{"name", "Leia" },
                     Attribute{ "surname", "Skywalker" } ) );
 
@@ -97,4 +97,3 @@ SCENARIO( "Simulating GNDS" ){
 
   }
 } // SCENARIO
-

--- a/src/knoop/Node/test/get.test.cpp
+++ b/src/knoop/Node/test/get.test.cpp
@@ -4,9 +4,8 @@
 using namespace njoy::knoop;
 using Node_t = Node<int, std::string>;
 
-// this functions are a workaround for isuues in the interaction between
-// C macros (like Catch's REQUIRE statement) and C++ template
-// instatiations;
+// This functions are a workaround for issues in the interaction between
+// C macros (like Catch's REQUIRE) and C++ template instantiations:
 
 int& getInt(Node_t& node);
 const int& getInt(const Node_t& node);
@@ -36,5 +35,13 @@ SCENARIO( "leaf node value extraction" ){
 
     REQUIRE_THROWS(getInt(sNode));
     REQUIRE_THROWS(getInt(csNode));
+  }
+
+  SECTION("a node with <one type> has a handy non-template get()"){
+    auto iNode = Node<int>{123};
+    auto jNode = Node<int>{456};
+
+    REQUIRE(iNode.get() == 123);
+    REQUIRE(jNode.get() == 456);
   }
 }

--- a/src/knoop/Node/test/list.test.cpp
+++ b/src/knoop/Node/test/list.test.cpp
@@ -4,9 +4,8 @@
 using namespace njoy::knoop;
 using Node_t = Node<int, std::string>;
 
-// this functions are a workaround for isuues in the interaction between
-// C macros (like Catch's REQUIRE statement) and C++ template
-// instatiations;
+// These functions are a workaround for issues in the interaction between
+// C macros (like Catch's REQUIRE) and C++ template instantiations:
 
 int& getInt(Node_t& node);
 const int& getInt(const Node_t& node);
@@ -14,6 +13,27 @@ std::string& getString(Node_t& node);
 const std::string& getString(const Node_t& node);
 
 SCENARIO( "list" ){
+  GIVEN( "a list Node" ){
+    WHEN( "the list Node is const" ){
+      // we'll set up a non-const node...
+      auto aNode = Node_t::makeList();
+      aNode.push_back(1).push_back("hello");
+      aNode.push_back("world", 2, 3);
+
+      // but we'll access it as const...
+      const auto& constNode = aNode;
+
+      THEN("list() can still be accessed"){
+        auto it = constNode.list().begin();
+        REQUIRE( getInt   (*it++) == 1 );
+        REQUIRE( getString(*it++) == "hello" );
+        REQUIRE( getString(*it++) == "world" );
+        REQUIRE( getInt   (*it++) == 2 );
+        REQUIRE( getInt   (*it++) == 3 );
+        REQUIRE( constNode.list().end() == it );
+      }
+    }
+  }
   GIVEN( "a list Node" ){
     WHEN( "values can be 'push_back'-ed" ){
       auto aNode = Node_t::makeList();
@@ -117,9 +137,13 @@ SCENARIO( "list" ){
   }
   GIVEN( "values to build a list Node" ){
     Node_t list{ 1, 2, "hello", 4, 5 };
+    const Node_t& constlist = list;
 
     REQUIRE( 1 == getInt( list.front() ) );
     REQUIRE( 5 == getInt( list.back() ) );
+
+    REQUIRE( 1 == getInt( constlist.front() ) );
+    REQUIRE( 5 == getInt( constlist.back() ) );
 
     auto it = list.list().begin();
     REQUIRE( 1 == getInt(*it) ); ++it;

--- a/src/knoop/Node/test/map.test.cpp
+++ b/src/knoop/Node/test/map.test.cpp
@@ -4,9 +4,8 @@
 using namespace njoy::knoop;
 using Node_t = Node<int, std::string>;
 
-// this functions are a workaround for isuues in the interaction between
-// C macros (like Catch's REQUIRE statement) and C++ template
-// instatiations;
+// These functions are a workaround for issues in the interaction between
+// C macros (like Catch's REQUIRE) and C++ template instantiations:
 
 int& getInt(Node_t& node);
 const int& getInt(const Node_t& node);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -12,5 +12,5 @@ $<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
 $<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
 
 ${CXX_appended_flags} ${knoop_appended_flags} )
-target_link_libraries( knoop.test PUBLIC knoop ) 
+target_link_libraries( knoop.test PUBLIC knoop )
 add_test( NAME knoop COMMAND knoop.test )

--- a/src/test/example1.cpp
+++ b/src/test/example1.cpp
@@ -43,11 +43,11 @@ int main( ){
       std::vector< double >{1.0, 2.0, 3.0, 4.0} };
   auto& vec = vNode.get< std::vector< double > >();
   cout << endl;
-  cout << "vNode has values: " 
-       << vec[0] << ", " 
-       << vec[1] << ", " 
-       << vec[2] << ", " 
-       << vec[3] << ", " 
+  cout << "vNode has values: "
+       << vec[0] << ", "
+       << vec[1] << ", "
+       << vec[2] << ", "
+       << vec[3] << ", "
        << endl;
 
   // Example of how to create nested nodes

--- a/src/test/nestedExample.cpp
+++ b/src/test/nestedExample.cpp
@@ -25,8 +25,8 @@ void nesting(){
 
   // This creates a child (sub) Node with an empty list
   mNode.put( "child", Node_t::makeList() );
-  
-  // This creates a child Node with a list that has been populated with the 
+
+  // This creates a child Node with a list that has been populated with the
   // values you provided in the constructor
   mNode.put( "child", Node_t{ 4, 5.5, "six" } );
 


### PR DESCRIPTION
Handy non-template get()s for Node<one type>.
Where wronged grammar.
Fixed tpyos.
Added const where possible.
Chucked EOL whitespace.
Added missing tests for three functions.